### PR TITLE
fix: обновлена версия libpq-dev в Dockerfile

### DIFF
--- a/docker/bot/Dockerfile
+++ b/docker/bot/Dockerfile
@@ -8,7 +8,7 @@ WORKDIR $HOME_DIR
 RUN apt-get update \
     && apt-get install -y --no-install-recommends \
         python3-dev=3.9.2-3 \
-        libpq-dev=13.8-0+deb11u1 \
+        libpq-dev=13.9-0+deb11u1 \
         build-essential=12.9 \
     && pip install --no-cache-dir poetry==1.2.2 \
     && apt-get clean \

--- a/docker/webapi/Dockerfile
+++ b/docker/webapi/Dockerfile
@@ -8,7 +8,7 @@ WORKDIR $HOME_DIR
 RUN apt-get update \
     && apt-get install -y --no-install-recommends \
         python3-dev=3.9.2-3 \
-        libpq-dev=13.8-0+deb11u1 \
+        libpq-dev=13.9-0+deb11u1 \
         build-essential=12.9 \
     && pip install --no-cache-dir poetry==1.2.2 \
     && apt-get clean \


### PR DESCRIPTION
Повышена версия 'libpq-dev' с 13.8 до 13.9 для устранения ошибки "E: Version '13.8-0+deb11u1' for 'libpq-dev' was not found" при сборке контейнеров.