### PR TITLE
fix: обновлен poetry.lock для согласования с pyproject.toml

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -452,6 +452,21 @@ Flask = "*"
 pydantic = ">=1.7"
 
 [[package]]
+name = "flask-rest-paginate"
+version = "1.1.3"
+description = "Pagination extension for flask-restful"
+category = "main"
+optional = false
+python-versions = "*"
+files = [
+    {file = "flask_rest_paginate-1.1.3-py3-none-any.whl", hash = "sha256:cd8f88210e959b8a2339003f76e303ae221ba7df190bef8714b474aa9c4a3e9d"},
+]
+
+[package.dependencies]
+flask-restful = "*"
+flask-sqlalchemy = "*"
+
+[[package]]
 name = "flask-restful"
 version = "0.3.9"
 description = "Simple framework for creating REST APIs"
@@ -1755,4 +1770,4 @@ email = ["email-validator"]
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.10"
-content-hash = "77c2e615febf41cfc67a4ff400d259786cbe37564f03546678d00701a7f117f0"
+content-hash = "7634d1bf1ce19cb9799692bd1989fb1bb136e8e3eba903ad68379306a51068f0"


### PR DESCRIPTION
Обновлен файл poetry.lock (через [poetry lock --no-update]), устранено рассогласование с pyproject.toml