### PR TITLE
fix: удаление дублирующихся строк в pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -71,11 +71,6 @@ exclude = '''
 )/
 '''
 
-exclude = '''
- /(
-   | migrations
- )/
- '''
 
 [tool.isort]
 line_length = 88


### PR DESCRIPTION
fix: удаление дублирующихся строк в pyproject.toml, возникших после слияния в автоматическом режиме